### PR TITLE
Harden model parsing and remove debug prints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ build-backend = "hatchling.build"
 [project.optional-dependencies]
 dev = [
     "pytest>=7.0.0",
+    "pytest-mock>=3.12.0",
     "pytest-cov>=4.0.0",
     "black>=23.0.0",
     "ruff>=0.1.0",

--- a/venice_sdk/audio.py
+++ b/venice_sdk/audio.py
@@ -6,10 +6,11 @@ This module provides text-to-speech capabilities using the Venice AI API.
 
 from __future__ import annotations
 
+import io
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union, Generator
-import io
 
 from .client import HTTPClient
 from .errors import VeniceAPIError, AudioGenerationError
@@ -19,6 +20,9 @@ try:
     import pygame
 except ImportError:
     pygame = None
+
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -342,8 +346,12 @@ class AudioBatchProcessor:
                     **kwargs
                 )
                 saved_files.append(saved_path)
-            except Exception as e:
-                print(f"Failed to process text {i}: {e}")
+            except Exception:
+                logger.warning(
+                    "Failed to process text index %s during batch audio generation",
+                    i,
+                    exc_info=True,
+                )
                 continue
         
         return saved_files


### PR DESCRIPTION
## Summary
- add a dedicated parser and logging so `get_models`/`get_model_by_id` survive missing keys without raising `KeyError`
- replace the lone debug print in the audio batch processor with structured logging and update the comprehensive audio tests
- wire in `pytest-mock` plus new unit tests that cover missing capabilities and malformed payloads so regressions get caught early

Fixes #11
Fixes #20

## Testing
- pytest tests/test_models.py tests/unit/test_audio_comprehensive.py