### PR TITLE
Improve HTTP client reuse and performance

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,10 @@ def mock_config():
     config.timeout = 30
     config.max_retries = 3
     config.retry_delay = 1
+    config.pool_connections = 10
+    config.pool_maxsize = 20
+    config.retry_backoff_factor = 0.5
+    config.retry_status_codes = [429, 500, 502, 503, 504]
     return config
 
 

--- a/venice_sdk/_http.py
+++ b/venice_sdk/_http.py
@@ -1,20 +1,67 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import Callable, Dict, Optional
 
-from .client import HTTPClient
-from . import config as _config
+from .client import HTTPClient, get_http_client_manager
+
+_manual_override_client: Optional[HTTPClient] = None
+_factory_http_clients: Dict[int, HTTPClient] = {}
+_http_client_manager = get_http_client_manager()
 
 
-def ensure_http_client(client: Optional[HTTPClient]) -> HTTPClient:
-    """Return a concrete HTTPClient, instantiating one if necessary."""
-    if client is not None:
-        return client
+def set_shared_http_client(client: Optional[HTTPClient]) -> None:
+    """Override the cached shared HTTP client (primarily for testing)."""
+    global _manual_override_client
+    _manual_override_client = client
+    if client is None:
+        _http_client_manager.clear()
+        _factory_http_clients.clear()
+
+
+def reset_shared_http_client() -> None:
+    """Clear the cached shared HTTP client so it will be recreated when needed."""
+    set_shared_http_client(None)
+
+
+def _default_http_client_factory(config: Optional["Config"] = None) -> HTTPClient:
+    """Build an HTTPClient via the unified VeniceClient for compatibility."""
     from .venice_client import VeniceClient
+    from .config import Config as _Config  # Local import to avoid cycles
 
-    config = _config.load_config()
-    venice_client = VeniceClient(config)
+    cfg: Optional[_Config] = config
+    venice_client = VeniceClient(cfg)
     http_client = getattr(venice_client, "http_client", None)
     if isinstance(http_client, HTTPClient):
         return http_client
+    if isinstance(venice_client, HTTPClient):
+        return venice_client
+    # Tests commonly patch VeniceClient to return a mock; fall back to that mock.
     return venice_client
+
+
+_http_client_manager.set_builder(_default_http_client_factory)
+
+
+def get_shared_http_client(
+    factory: Optional[Callable[[], HTTPClient]] = None
+) -> HTTPClient:
+    """Return the cached shared HTTP client, creating it on first use."""
+    if factory is None:
+        if _manual_override_client is not None:
+            return _manual_override_client
+        return _http_client_manager.get_client()
+
+    key = id(factory)
+    if key not in _factory_http_clients:
+        _factory_http_clients[key] = factory()
+    return _factory_http_clients[key]
+
+
+def ensure_http_client(
+    client: Optional[HTTPClient],
+    factory: Optional[Callable[[], HTTPClient]] = None,
+) -> HTTPClient:
+    """Return a concrete HTTPClient, instantiating one if necessary."""
+    if client is not None:
+        return client
+    return get_shared_http_client(factory=factory)

--- a/venice_sdk/chat.py
+++ b/venice_sdk/chat.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, Generator, List, Optional, Union, cast
 
 from .client import HTTPClient
+from ._http import ensure_http_client
 from .errors import VeniceAPIError
 
 JSONDict = Dict[str, Any]
@@ -357,8 +358,8 @@ def chat_complete(
         ValueError: If messages is empty or temperature is invalid
         VeniceAPIError: If the request fails
     """
-    client = client or HTTPClient()
-    chat_api = ChatAPI(client)
+    http_client = ensure_http_client(client, factory=HTTPClient)
+    chat_api = ChatAPI(http_client)
     return chat_api.complete(
         messages=messages,
         model=model,

--- a/venice_sdk/client.py
+++ b/venice_sdk/client.py
@@ -2,13 +2,16 @@
 Core HTTP client for the Venice SDK.
 """
 
+import hashlib
 import json
 import logging
-import time
-from typing import Any, Dict, Generator, Optional, Union
+import threading
+from typing import Any, Callable, Dict, Generator, Optional, Union
 
 import requests
 from requests import Response
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 from .config import Config, load_config
 from .errors import VeniceAPIError, VeniceConnectionError, handle_api_error
@@ -37,6 +40,23 @@ class HTTPClient:
             "Authorization": f"Bearer {self.config.api_key}",
             "Content-Type": "application/json"
         })
+        retry_strategy = Retry(
+            total=self.config.max_retries,
+            status_forcelist=self.config.retry_status_codes,
+            allowed_methods=frozenset(
+                ["HEAD", "GET", "OPTIONS", "POST", "PUT", "DELETE", "PATCH"]
+            ),
+            backoff_factor=self.config.retry_backoff_factor,
+            raise_on_status=False,
+            respect_retry_after_header=True,
+        )
+        adapter = HTTPAdapter(
+            max_retries=retry_strategy,
+            pool_connections=self.config.pool_connections,
+            pool_maxsize=self.config.pool_maxsize,
+        )
+        self.session.mount("https://", adapter)
+        self.session.mount("http://", adapter)
     
     def _request(
         self,
@@ -77,133 +97,93 @@ class HTTPClient:
         if "timeout" not in kwargs:
             kwargs["timeout"] = self.config.timeout
         
-        # Add retry logic
-        for attempt in range(self.config.max_retries):
+        try:
+            response = self.session.request(
+                method,
+                url,
+                json=data,
+                stream=stream,
+                **kwargs,
+            )
+        except requests.exceptions.RequestException as e:
+            logger.error(
+                "HTTP %s %s raised %s",
+                method.upper(),
+                url,
+                type(e).__name__,
+                exc_info=True,
+            )
+            raise VeniceConnectionError(
+                f"Request failed: {str(e)}",
+                context={"method": method.upper(), "url": url},
+                cause=e,
+            ) from e
+
+        if response.status_code >= 400:
+            logger.warning(
+                "HTTP %s %s failed with status %s",
+                method.upper(),
+                url,
+                response.status_code,
+            )
+            parse_error: Optional[Exception] = None
             try:
-                response = self.session.request(
-                    method,
-                    url,
-                    json=data,
-                    stream=stream,
-                    **kwargs
-                )
-                
-                # Common error handling (non-2xx)
-                if response.status_code >= 400:
-                    logger.warning(
-                        "HTTP %s %s failed with status %s (attempt %s/%s)",
-                        method.upper(),
-                        url,
-                        response.status_code,
-                        attempt + 1,
-                        self.config.max_retries,
-                    )
-                    # Attempt to parse error payload safely
-                    parse_error: Optional[Exception] = None
-                    try:
-                        error_data = response.json() or {}
-                    except ValueError as json_error:
-                        parse_error = json_error
-                        error_data = {"error": {"message": response.text or "Unknown error"}}
+                error_data = response.json() or {}
+            except ValueError as json_error:
+                parse_error = json_error
+                error_data = {"error": {"message": response.text or "Unknown error"}}
 
-                    # Normalize string error payloads to dict form
-                    if isinstance(error_data.get("error"), str):
-                        error_data = {"error": {"message": error_data.get("error")}}
+            if isinstance(error_data.get("error"), str):
+                error_data = {"error": {"message": error_data.get("error")}}
 
-                    status = response.status_code
-
-                    # Determine if this error is retriable
-                    is_rate_limited = status == 429
-                    is_server_error = status >= 500
-
-                    # Calculate retry delay using Retry-After header if present
-                    retry_after_header = response.headers.get("Retry-After") if hasattr(response, "headers") else None
+            retry_after_header = (
+                response.headers.get("Retry-After") if hasattr(response, "headers") else None
+            )
+            retry_after_seconds = None
+            if retry_after_header is not None:
+                try:
+                    retry_after_seconds = int(retry_after_header)
+                except (TypeError, ValueError):
                     retry_after_seconds = None
-                    if retry_after_header is not None:
-                        try:
-                            retry_after_seconds = int(retry_after_header)
-                        except (TypeError, ValueError):
-                            retry_after_seconds = None
 
-                    # If 429 and body lacks retry_after, inject from header for better error context
-                    if is_rate_limited:
-                        error_obj = error_data.get("error") or {}
-                        if isinstance(error_obj, dict) and error_obj.get("retry_after") is None and retry_after_seconds is not None:
-                            error_obj["retry_after"] = retry_after_seconds
-                            error_data["error"] = error_obj
+            if response.status_code == 429:
+                error_obj = error_data.get("error") or {}
+                if (
+                    isinstance(error_obj, dict)
+                    and error_obj.get("retry_after") is None
+                    and retry_after_seconds is not None
+                ):
+                    error_obj["retry_after"] = retry_after_seconds
+                    error_data["error"] = error_obj
 
-                    error_context_extra = {
-                        "method": method.upper(),
-                        "url": url,
-                        "attempt": attempt + 1,
-                        "stream": stream,
-                    }
-                    if hasattr(response, "headers"):
-                        request_id_header = response.headers.get("X-Request-ID") or response.headers.get("x-request-id")
-                        if request_id_header:
-                            error_context_extra["request_id"] = request_id_header
-                        if retry_after_header is not None:
-                            error_context_extra["retry_after_header"] = retry_after_header
+            error_context_extra = {
+                "method": method.upper(),
+                "url": url,
+                "stream": stream,
+            }
+            if hasattr(response, "headers"):
+                request_id_header = response.headers.get("X-Request-ID") or response.headers.get("x-request-id")
+                if request_id_header:
+                    error_context_extra["request_id"] = request_id_header
+                if retry_after_header is not None:
+                    error_context_extra["retry_after_header"] = retry_after_header
 
-                    # Retry on 429 and 5xx if attempts remain
-                    if (is_rate_limited or is_server_error) and attempt < self.config.max_retries - 1:
-                        delay_seconds = retry_after_seconds if retry_after_seconds is not None else self.config.retry_delay * (2 ** attempt)
-                        logger.info(
-                            "Retrying HTTP %s %s after %ss delay (attempt %s/%s)",
-                            method.upper(),
-                            url,
-                            delay_seconds,
-                            attempt + 1,
-                            self.config.max_retries,
-                        )
-                        time.sleep(delay_seconds)
-                        continue
+            handle_api_error(
+                response.status_code,
+                error_data,
+                extra_context=error_context_extra,
+                cause=parse_error,
+            )
+            return response
 
-                    # No retry or attempts exhausted: raise specific API error
-                    handle_api_error(
-                        status,
-                        error_data,
-                        extra_context=error_context_extra,
-                        cause=parse_error,
-                    )
-                    # handle_api_error always raises; the following return is unreachable.
-                    return response
-
-                # Success
-                logger.debug(
-                    "HTTP %s %s succeeded with status %s (stream=%s)",
-                    method.upper(),
-                    url,
-                    response.status_code,
-                    stream,
-                )
-                return response
-                
-            except requests.exceptions.RequestException as e:
-                logger.error(
-                    "HTTP %s %s raised %s on attempt %s/%s",
-                    method.upper(),
-                    url,
-                    type(e).__name__,
-                    attempt + 1,
-                    self.config.max_retries,
-                    exc_info=True,
-                )
-                if attempt == self.config.max_retries - 1:
-                    raise VeniceConnectionError(
-                        f"Request failed after {self.config.max_retries} attempts: {str(e)}",
-                        context={
-                            "method": method.upper(),
-                            "url": url,
-                            "attempt": attempt + 1,
-                        },
-                        cause=e,
-                    ) from e
-                time.sleep(2 ** attempt)  # Exponential backoff
-        raise VeniceConnectionError(
-            f"Request failed after {self.config.max_retries} attempts: exhausted retry loop",
-            context={"method": method.upper(), "url": url},
+        logger.debug(
+            "HTTP %s %s succeeded with status %s (stream=%s)",
+            method.upper(),
+            url,
+            response.status_code,
+            stream,
         )
+        return response
     
     def _handle_streaming_response(self, response: Response) -> Generator[Dict[str, Any], None, None]:
         """
@@ -306,3 +286,84 @@ class HTTPClient:
     def delete(self, endpoint: str, **kwargs: Any) -> Response:
         """Make a DELETE request."""
         return self._request("DELETE", endpoint, **kwargs)
+
+    def _make_request(
+        self,
+        method: str,
+        endpoint: str,
+        data: Optional[Dict[str, Any]] = None,
+        stream: bool = False,
+        **kwargs: Any,
+    ):
+        """Backward compatible wrapper for legacy callers expecting `_make_request`."""
+        response = self._request(method, endpoint, data=data, stream=stream, **kwargs)
+        if stream:
+            return self._handle_streaming_response(response)
+        return response
+
+
+class HTTPClientManager:
+    """Manages pooled HTTPClient instances keyed by configuration."""
+
+    def __init__(self, builder: Optional[Callable[[Config], HTTPClient]] = None):
+        self._builder: Callable[[Config], HTTPClient] = builder or (lambda cfg: HTTPClient(cfg))
+        self._clients: Dict[str, HTTPClient] = {}
+        self._lock = threading.Lock()
+
+    def set_builder(self, builder: Callable[[Config], HTTPClient]) -> None:
+        """Override the client builder and clear existing cache."""
+        with self._lock:
+            self._builder = builder
+            self._clients.clear()
+
+    def _ensure_config(self, config: Optional[Config]) -> Config:
+        return config or load_config()
+
+    def _config_key(self, config: Config) -> str:
+        """Create a stable cache key without exposing sensitive data."""
+        api_key_hash = hashlib.sha256(config.api_key.encode("utf-8")).hexdigest()
+        raw = "|".join(
+            [
+                api_key_hash,
+                config.base_url or "",
+                config.default_model or "",
+                str(config.timeout),
+                str(config.max_retries),
+                str(config.retry_delay),
+            ]
+        )
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+    def get_client(self, config: Optional[Config] = None, force_refresh: bool = False) -> HTTPClient:
+        """Retrieve a cached HTTP client for the provided configuration."""
+        cfg = self._ensure_config(config)
+        cache_key = self._config_key(cfg)
+
+        if not force_refresh:
+            with self._lock:
+                cached = self._clients.get(cache_key)
+                if cached is not None:
+                    return cached
+
+        client = self._builder(cfg)
+        if isinstance(client, HTTPClient):
+            with self._lock:
+                self._clients[cache_key] = client
+        return client
+
+    def clear(self, config: Optional[Config] = None) -> None:
+        """Clear cached clients (all or specific configuration)."""
+        with self._lock:
+            if config is None:
+                self._clients.clear()
+                return
+            cache_key = self._config_key(self._ensure_config(config))
+            self._clients.pop(cache_key, None)
+
+
+_http_client_manager = HTTPClientManager()
+
+
+def get_http_client_manager() -> HTTPClientManager:
+    """Return the process-wide HTTP client manager."""
+    return _http_client_manager

--- a/venice_sdk/config.py
+++ b/venice_sdk/config.py
@@ -3,7 +3,7 @@ Configuration management for the Venice SDK.
 """
 
 import os
-from typing import Dict, Optional
+from typing import Dict, Iterable, List, Optional
 from dotenv import load_dotenv
 
 
@@ -17,7 +17,11 @@ class Config:
         default_model: Optional[str] = None,
         timeout: Optional[int] = None,
         max_retries: Optional[int] = None,
-        retry_delay: Optional[int] = None
+        retry_delay: Optional[int] = None,
+        pool_connections: Optional[int] = None,
+        pool_maxsize: Optional[int] = None,
+        retry_backoff_factor: Optional[float] = None,
+        retry_status_codes: Optional[Iterable[int]] = None,
     ):
         """
         Initialize the configuration.
@@ -42,6 +46,16 @@ class Config:
         self.timeout = timeout if timeout is not None else 30
         self.max_retries = max_retries if max_retries is not None else 3
         self.retry_delay = retry_delay if retry_delay is not None else 1
+        self.pool_connections = pool_connections if pool_connections is not None else 10
+        self.pool_maxsize = pool_maxsize if pool_maxsize is not None else 20
+        self.retry_backoff_factor = (
+            retry_backoff_factor if retry_backoff_factor is not None else 0.5
+        )
+        default_retry_statuses: List[int] = [429, 500, 502, 503, 504]
+        if retry_status_codes is None:
+            self.retry_status_codes = default_retry_statuses
+        else:
+            self.retry_status_codes = list(retry_status_codes) or default_retry_statuses
 
     @property
     def headers(self) -> Dict[str, str]:
@@ -108,11 +122,36 @@ def load_config(api_key: Optional[str] = None) -> Config:
     retry_delay_str = os.getenv("VENICE_RETRY_DELAY", "1")
     retry_delay = int(retry_delay_str) if retry_delay_str else 1
     
+    pool_connections_str = os.getenv("VENICE_POOL_CONNECTIONS", "10")
+    pool_connections = int(pool_connections_str) if pool_connections_str else 10
+
+    pool_maxsize_str = os.getenv("VENICE_POOL_MAXSIZE", "20")
+    pool_maxsize = int(pool_maxsize_str) if pool_maxsize_str else 20
+
+    retry_backoff_str = os.getenv("VENICE_RETRY_BACKOFF_FACTOR", "0.5")
+    retry_backoff_factor = float(retry_backoff_str) if retry_backoff_str else 0.5
+
+    retry_status_codes_env = os.getenv("VENICE_RETRY_STATUS_CODES")
+    retry_status_codes: Optional[List[int]] = None
+    if retry_status_codes_env:
+        try:
+            retry_status_codes = [
+                int(code.strip())
+                for code in retry_status_codes_env.split(",")
+                if code.strip()
+            ]
+        except ValueError:
+            retry_status_codes = None
+
     return Config(
         api_key=api_key,
         base_url=base_url,
         default_model=default_model,
         timeout=timeout,
         max_retries=max_retries,
-        retry_delay=retry_delay
-    ) 
+        retry_delay=retry_delay,
+        pool_connections=pool_connections,
+        pool_maxsize=pool_maxsize,
+        retry_backoff_factor=retry_backoff_factor,
+        retry_status_codes=retry_status_codes,
+    )

--- a/venice_sdk/models.py
+++ b/venice_sdk/models.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional, cast
 
 from .client import HTTPClient
 from .errors import VeniceAPIError, VeniceConnectionError
+from ._http import ensure_http_client
 
 
 @dataclass
@@ -114,8 +115,8 @@ def get_models(client: Optional[HTTPClient] = None) -> List[Model]:
     Raises:
         VeniceAPIError: If the request fails.
     """
-    client = client or HTTPClient()
-    models_api = ModelsAPI(client)
+    http_client = ensure_http_client(client, factory=HTTPClient)
+    models_api = ModelsAPI(http_client)
     models_data = models_api.list()
     
     models = []
@@ -136,8 +137,8 @@ def get_model_by_id(model_id: str, client: Optional[HTTPClient] = None) -> Optio
     Returns:
         Model if found, None otherwise.
     """
-    client = client or HTTPClient()
-    models_api = ModelsAPI(client)
+    http_client = ensure_http_client(client, factory=HTTPClient)
+    models_api = ModelsAPI(http_client)
     model_data = models_api.get(model_id)
     return _build_model_from_data(model_data)
 


### PR DESCRIPTION
## Summary
- introduce an HTTPClientManager and route convenience wrappers through ensure_http_client so shared sessions respect config-specific pools (Fixes #10, Fixes #26)
- add pool/retry tuning knobs to Config, mount a tuned HTTPAdapter/Retry in HTTPClient, and simplify request handling (Fixes #18)
- expand client unit tests to cover the manager and new retry behavior and keep existing suites green

## Testing
- pytest tests/test_client.py
- ~/.local/bin/pytest tests/test_chat.py tests/test_models.py tests/unit/test_images_comprehensive.py tests/unit/test_audio_comprehensive.py tests/unit/test_characters_comprehensive.py tests/unit/test_account_comprehensive.py tests/unit/test_embeddings_comprehensive.py tests/unit/test_models_advanced_comprehensive.py